### PR TITLE
refactor: migrate to SecretsManager pattern

### DIFF
--- a/rodin/griptape-nodes-library.json
+++ b/rodin/griptape-nodes-library.json
@@ -3,10 +3,12 @@
     "library_schema_version": "0.1.0",
     "settings": [
         {
-            "description": "Environment variables for storing Rodin API credentials",
-            "category": "nodes.Rodin",
+            "description": "API keys required by nodes in this library",
+            "category": "app_events.on_app_initialization_complete",
             "contents": {
-                "RODIN_API_KEY": "$RODIN_API_KEY"
+                "secrets_to_register": [
+                    "RODIN_API_KEY"
+                ]
             }
         }
     ],

--- a/rodin/rodin_3d_generator.py
+++ b/rodin/rodin_3d_generator.py
@@ -1,6 +1,4 @@
-import os
 import time
-import tempfile
 import json
 import requests
 from typing import Any
@@ -228,7 +226,7 @@ class Rodin3DGenerator(ControlNode):
         Returns:
             list[Exception] | None: List of exceptions if validation fails, None if validation passes.
         """
-        api_key = self.get_config_value(service=SERVICE, value=API_KEY_ENV_VAR)
+        api_key = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
 
         errors = []
         if not api_key:
@@ -251,9 +249,9 @@ class Rodin3DGenerator(ControlNode):
                 self.parameter_output_values["task_uuid"] = ""
                 logger.debug("✅ Initialization complete")
 
-                # Get API key from environment
-                logger.debug("🔑 Getting API key from config...")
-                api_key = self.get_config_value(service=SERVICE, value=API_KEY_ENV_VAR)
+                # Get API key from secrets manager
+                logger.debug("🔑 Getting API key from secrets manager...")
+                api_key = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
                 logger.debug(f"🔑 API key retrieved: {bool(api_key)} (length: {len(api_key) if api_key else 0})")
                 if not api_key or not api_key.strip():
                     logger.debug("❌ API key validation failed")


### PR DESCRIPTION
- Updated rodin_3d_generator.py to use GriptapeNodes.SecretsManager().get_secret()
- Replaced get_config_value(service=SERVICE, value=API_KEY_ENV_VAR) pattern in both validate_node() and process()
- Removed unused os and tempfile imports
- Updated griptape-nodes-library.json to use secrets_to_register array
- Changed category to app_events.on_app_initialization_complete
- Maintains backwards compatibility with same error messages