### PR TITLE
fix: add ExistingFilePolicy.CREATE_NEW to save_static_file call to prevent race conditions

### DIFF
--- a/rodin/griptape-nodes-library.json
+++ b/rodin/griptape-nodes-library.json
@@ -15,8 +15,8 @@
     "metadata": {
         "author": "Griptape",
         "description": "Nodes for generating 3D models using the Rodin API",
-        "library_version": "0.1.0",
-        "engine_version": "0.39.0",
+        "library_version": "0.1.1",
+        "engine_version": "0.66.0",
         "tags": [
             "Griptape",
             "AI",

--- a/rodin/rodin_3d_generator.py
+++ b/rodin/rodin_3d_generator.py
@@ -7,6 +7,7 @@ from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, Parame
 from griptape_nodes.exe_types.node_types import DataNode, ControlNode, AsyncResult
 from griptape_nodes.traits.options import Options
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
+from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 
 SERVICE = "Rodin"
 API_KEY_ENV_VAR = "RODIN_API_KEY"
@@ -595,7 +596,7 @@ class Rodin3DGenerator(ControlNode):
                 static_filename = f"rodin_3d_{timestamp}_{index+1}_{base_name}.{safe_suffix}"
 
                 logger.debug(f"💾 Saving {original_name} as {static_filename}...")
-                static_url = static_files_manager.save_static_file(file_bytes, static_filename)
+                static_url = static_files_manager.save_static_file(file_bytes, static_filename, ExistingFilePolicy.CREATE_NEW)
                 logger.debug(f"🔗 Local URL for {original_name}: {static_url}")
 
                 local_file_names.append(static_filename)


### PR DESCRIPTION
## Important!!!
Do not merge until https://github.com/griptape-ai/griptape-nodes/pull/3374 has made to a stable release. This requires a new parameter to be available to `StaticFilesManager().save_static_file`

Fixes https://github.com/griptape-ai/griptape-nodes/issues/3373