### PR TITLE
feat: replace bespoke loading logic with File class

### DIFF
--- a/rodin/griptape-nodes-library.json
+++ b/rodin/griptape-nodes-library.json
@@ -16,7 +16,7 @@
         "author": "Griptape",
         "description": "Nodes for generating 3D models using the Rodin API",
         "library_version": "0.1.1",
-        "engine_version": "0.66.0",
+        "engine_version": "0.75.0",
         "tags": [
             "Griptape",
             "AI",

--- a/rodin/rodin_3d_generator.py
+++ b/rodin/rodin_3d_generator.py
@@ -8,6 +8,7 @@ from griptape_nodes.exe_types.node_types import DataNode, ControlNode, AsyncResu
 from griptape_nodes.traits.options import Options
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
+from griptape_nodes.files.file import File, FileLoadError
 
 SERVICE = "Rodin"
 API_KEY_ENV_VAR = "RODIN_API_KEY"
@@ -430,11 +431,10 @@ class Rodin3DGenerator(ControlNode):
                     raise ValueError(f"Image {i+1} must be an ImageUrlArtifact")
                 
                 # Download image content
-                image_response = requests.get(image_artifact.value, timeout=30)
-                image_response.raise_for_status()
+                image_bytes = File(image_artifact.value).read_bytes()
                 
                 # Add to files for multipart upload
-                files.append(('images', (f'image_{i+1}.jpg', image_response.content, 'image/jpeg')))
+                files.append(('images', (f'image_{i+1}.jpg', image_bytes, 'image/jpeg')))
 
             # Add condition_mode for multi-image
             if len(images_input) > 1:


### PR DESCRIPTION
## Summary
- Replace user-input image URL download with `File(url).read_bytes()`
- Streaming result downloads preserved as-is (not supported by File)
- Bump `engine_version` to `0.75.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)