### PR TITLE
fix: use ProjectFileDestination.from_situation() instead of direct constructor

### DIFF
--- a/rodin/griptape-nodes-library.json
+++ b/rodin/griptape-nodes-library.json
@@ -16,7 +16,7 @@
         "author": "Griptape",
         "description": "Nodes for generating 3D models using the Rodin API",
         "library_version": "0.1.1",
-        "engine_version": "0.75.0",
+        "engine_version": "0.77.5",
         "tags": [
             "Griptape",
             "AI",

--- a/rodin/rodin_3d_generator.py
+++ b/rodin/rodin_3d_generator.py
@@ -606,7 +606,7 @@ class Rodin3DGenerator(ControlNode):
                 # Save using project-aware file destination
                 safe_suffix = original_name.rsplit(".", 1)[-1] if "." in original_name else "bin"
                 base_name = original_name.rsplit(".", 1)[0] if "." in original_name else original_name
-                dest = ProjectFileDestination(
+                dest = ProjectFileDestination.from_situation(
                     filename=f"rodin_3d_{base_name}.{safe_suffix}", situation="save_node_output"
                 )
                 saved = dest.write_bytes(file_bytes)


### PR DESCRIPTION
`ProjectFileDestination.__init__` no longer accepts `filename`, `situation`, and `**extra_vars` directly — that logic was moved to the `from_situation()` classmethod in griptape-nodes commit `4e2047412`. This updates the direct constructor call in `rodin_3d_generator.py` to use `ProjectFileDestination.from_situation(...)` instead.